### PR TITLE
[#4] 공통 컴포넌트 - Circle 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,29 +30,7 @@
     "react/require-default-props": "off",
     "react/jsx-no-useless-fragment": "warn",
     "react-hooks/exhaustive-deps": "off",
-    "import/prefer-default-export": "off",
-    "import/order": [
-      "error",
-      {
-        "groups": [
-          "external",
-          "builtin",
-          "internal",
-          "parent",
-          "sibling",
-          "index",
-          "object"
-        ],
-        "pathGroups": [
-          {
-            "pattern": "react*",
-            "group": "external",
-            "position": "before"
-          }
-        ],
-        "pathGroupsExcludedImportTypes": ["react*"]
-      }
-    ]
+    "import/prefer-default-export": "off"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
           href="https://webfontworld.github.io/NexonLv2Gothic/NexonLv2Gothic.css"
         />
       </head>
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,13 @@
+import ColorCircle from '@/components/commons/circle/ColorCircle';
+import ProfileCircle from '@/components/commons/circle/ProfileCircle';
+
+export default function ComponentTest() {
+  return (
+    <>
+      <ColorCircle color="bg-toss-blue" size="sm" />
+      <ProfileCircle color="bg-[#a3c4a2]" size="lg">
+        <span className="font-bold text-white">B</span>
+      </ProfileCircle>
+    </>
+  );
+}

--- a/src/components/commons/circle/ColorCircle.tsx
+++ b/src/components/commons/circle/ColorCircle.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import classNames from 'classnames';
+
+type Props = {
+  color: string;
+  size: 'sm' | 'lg';
+};
+
+export default function ColorCircle({ color, size }: Props) {
+  const classnames = classNames('rounded-full', color, {
+    'size-2': size === 'sm',
+    'size-[30px]': size === 'lg',
+  });
+
+  return <div className={classnames} />;
+}

--- a/src/components/commons/circle/ProfileCircle.tsx
+++ b/src/components/commons/circle/ProfileCircle.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+type Props = {
+  color: string;
+  size: 'md' | 'lg';
+  children: ReactNode;
+};
+
+export default function ProfileCircle({ color, size, children }: Props) {
+  const classnames = classNames(
+    'rounded-full ring-2 ring-white flex justify-center items-center ',
+    color,
+    {
+      'size-[34px]': size === 'md',
+      'size-[38px]': size === 'lg',
+    },
+  );
+
+  return <div className={classnames}>{children}</div>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,6 +850,11 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 cli-cursor@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
@@ -2920,16 +2925,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3002,14 +2998,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## ✨ Done

- [x] ColorCircle.tsx
- [x] ProfileCircle.tsx

## ✅ 주요 변경사항

- Circle 공통 컴포넌트를 구현하였습니다.
- 임시로 /test 페이지를 생성하여 컴포넌트를 테스트했습니다.
- import 정렬과 관련된 eslint와 prettier 충돌 문제를 해결하기 위해 eslint 부분을 삭제했습니다.

<br>

### 🛑 컴포넌트 사용 시 주의 사항

color props를 내려줄 때는 완전한 tailwind class를 내려주세요!

❌ 예시

```tsx
export default function ComponentTest() {
   return <ColorCircle color="#f6f" size="sm" />;
}
```

```tsx
export default function ComponentTest() {
  const customColor = "#f6f"

  return <ColorCircle color={`bg-[${customColor}]`} size="sm" />;
}
```

⭕ 예시

```tsx
export default function ComponentTest() {
   return <ColorCircle color="bg-toss-blue" size="sm" />;
}
```

참고 자료: https://tailwindcss.com/docs/content-configuration#dynamic-class-names