### PR TITLE
[#46] ProfileCircle 컴포넌트 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/taskify/**',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
-        port: '',
-        pathname: '/taskify/**',
-      },
-    ],
+    domains: ['sprint-fe-project.s3.ap-northeast-2.amazonaws.com'],
   },
 };
 

--- a/src/app/test/card/page.tsx
+++ b/src/app/test/card/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import BarButton from '@/components/commons/button/BarButton';
-import ProfileCircle from '@/components/commons/circle/ProfileCircle';
 import CreateCardModal from '@/components/dashboard/CreateCardModal';
 import { useState } from 'react';
 
@@ -16,14 +15,8 @@ export default function CreateCard() {
     setIsModalOpen(false);
   };
 
-  const DATA = {
-    nickname: 'Goni',
-    profileImageUrl: '/image/logo_blue.png',
-  };
-
   return (
     <div className="m-auto mt-[40vh] w-1/5">
-      <ProfileCircle styles="size-28 bg-slate-400" data={DATA} />
       <BarButton onClick={openModal} />
       <CreateCardModal
         isOpen={isModalOpen}

--- a/src/app/test/card/page.tsx
+++ b/src/app/test/card/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import BarButton from '@/components/commons/button/BarButton';
+import ProfileCircle from '@/components/commons/circle/ProfileCircle';
 import CreateCardModal from '@/components/dashboard/CreateCardModal';
 import { useState } from 'react';
 
@@ -15,8 +16,14 @@ export default function CreateCard() {
     setIsModalOpen(false);
   };
 
+  const DATA = {
+    nickname: 'Goni',
+    profileImageUrl: '/image/logo_blue.png',
+  };
+
   return (
     <div className="m-auto mt-[40vh] w-1/5">
+      <ProfileCircle styles="size-28 bg-slate-400" data={DATA} />
       <BarButton onClick={openModal} />
       <CreateCardModal
         isOpen={isModalOpen}

--- a/src/components/commons/circle/ProfileCircle.tsx
+++ b/src/components/commons/circle/ProfileCircle.tsx
@@ -1,18 +1,12 @@
 import Image from 'next/image';
 
-type Member = {
-  // id: number;
-  // userId: number;
-  // email: string;
+type User = {
   nickname: string;
   profileImageUrl: string | null;
-  // createdAt: string;
-  // updatedAt: string;
-  // isOwner: boolean;
 };
 
 type Props = {
-  data: Member;
+  data: User;
   styles: string;
 };
 
@@ -21,7 +15,7 @@ export default function ProfileCircle({ styles, data }: Props) {
 
   return (
     <div
-      className={`'rounded-full cursor-pointer' relative flex transform cursor-pointer items-center justify-center rounded-full text-white ring-2 ring-white transition-transform duration-200 ease-in-out hover:scale-110 ${styles}`}
+      className={`relative flex transform cursor-pointer items-center justify-center rounded-full text-white ring-2 ring-white transition-transform duration-200 ease-in-out hover:scale-110 ${styles}`}
     >
       {profileImageUrl ? (
         <Image
@@ -31,7 +25,7 @@ export default function ProfileCircle({ styles, data }: Props) {
           className="absolute rounded-full object-cover"
         />
       ) : (
-        <span className="text-white">{nickname[0]}</span>
+        <span className="mr-[0.5px] mt-1 text-white">{nickname[0]}</span>
       )}
     </div>
   );

--- a/src/components/commons/circle/ProfileCircle.tsx
+++ b/src/components/commons/circle/ProfileCircle.tsx
@@ -21,7 +21,7 @@ export default function ProfileCircle({ styles, data }: Props) {
 
   return (
     <div
-      className={`relative flex items-center justify-center rounded-full ring-2 ring-white ${styles}`}
+      className={`relative flex cursor-pointer items-center justify-center rounded-full ring-2 ring-white ${styles}`}
     >
       {profileImageUrl ? (
         <Image

--- a/src/components/commons/circle/ProfileCircle.tsx
+++ b/src/components/commons/circle/ProfileCircle.tsx
@@ -1,24 +1,38 @@
-'use client';
+import Image from 'next/image';
 
-import classNames from 'classnames';
-import { ReactNode } from 'react';
-
-type Props = {
-  color: string;
-  size: 'sm' | 'md' | 'lg';
-  children: ReactNode;
+type Member = {
+  // id: number;
+  // userId: number;
+  // email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+  // createdAt: string;
+  // updatedAt: string;
+  // isOwner: boolean;
 };
 
-export default function ProfileCircle({ color, size, children }: Props) {
-  const classnames = classNames(
-    'rounded-full ring-2 ring-white flex justify-center items-center ',
-    color,
-    {
-      'size-26': size === 'sm',
-      'size-34': size === 'md',
-      'size-38': size === 'lg',
-    },
-  );
+type Props = {
+  data: Member;
+  styles: string;
+};
 
-  return <div className={classnames}>{children}</div>;
+export default function ProfileCircle({ styles, data }: Props) {
+  const { profileImageUrl, nickname } = data;
+
+  return (
+    <div
+      className={`relative flex items-center justify-center rounded-full ring-2 ring-white ${styles}`}
+    >
+      {profileImageUrl ? (
+        <Image
+          src={profileImageUrl}
+          fill
+          alt="profile"
+          className="absolute rounded-full object-cover"
+        />
+      ) : (
+        <span className="text-white">{nickname[0]}</span>
+      )}
+    </div>
+  );
 }

--- a/src/components/dashboard/CreateCardModal/index.tsx
+++ b/src/components/dashboard/CreateCardModal/index.tsx
@@ -27,7 +27,7 @@ export type CreateCardInputs = {
   assignee: number;
   title: string;
   description: string;
-  dueDate: Date;
+  dueDate?: Date;
   tags?: string[];
   image?: string;
 };
@@ -56,7 +56,7 @@ export default function CreateCardModal({
       title,
       description,
       tags,
-      dueDate: formatDate(dueDate),
+      dueDate: dueDate && formatDate(dueDate),
       imageUrl: image,
     };
 


### PR DESCRIPTION
## ✨ Done

- [x] Profile 데이터 받아서 내부에서 처리

## ✅ 주요 변경사항

- 외부 이미지 받아올 수 있도록 next.config.mjs 변경

## 📸 스크린샷

- profileImageUrl이 null일 때
![스크린샷 2024-06-27 172418](https://github.com/13teamProject/Planit/assets/102004889/8008f5b4-3f42-466d-ab79-bf0b6838de31)

- profileImageUrl이 있을 때
![스크린샷 2024-06-27 172432](https://github.com/13teamProject/Planit/assets/102004889/4cf39349-18aa-4a16-b07d-6f354eff3a8e)

## 사용 방법

size, 배경색, text 크기를 styles prop으로 내려주시면 됩니다.

```tsx
<ProfileCircle styles="size-26 md:size-34 bg-slate-400 text-14" data={DATA} />
```

추가로 현재 ProfileCircle 크기 찾아봤는데 종류가 이 정도 있는 것 같습니다.

- `size-22 md:size-24`
- `size-26 md:size-34`
- `size-34 md:size-38`
- `size-26`


_현재 이 컴포넌트 사용하시는 분이 서연님이신 것 같은데 확인해주시면 감사하겠습니다!_
