### PR TITLE
[#71] 대시보드 관리 - 대시보드 삭제

### DIFF
--- a/@types/commons.d.ts
+++ b/@types/commons.d.ts
@@ -7,4 +7,10 @@ declare module '@planit-types' {
     isOpen: boolean;
     message: string;
   };
+
+  export type ContentModalState = {
+    isOpen: boolean;
+    message: string;
+    isContent?: boolean;
+  };
 }

--- a/src/app/(dashboard)/edit/[id]/page.tsx
+++ b/src/app/(dashboard)/edit/[id]/page.tsx
@@ -1,3 +1,4 @@
+import DashboardDeleteButton from '@/components/dashboard/edits/DashboardDeleteButton';
 import DashboardInvitation from '@/components/dashboard/edits/DashboardInvitation';
 import DashboardMember from '@/components/dashboard/edits/DashboardMember';
 import DashboardName from '@/components/dashboard/edits/DashboardName';
@@ -8,6 +9,7 @@ export default function Edit({ params }: { params: { id: number } }) {
       <DashboardName params={params} />
       <DashboardMember params={params} />
       <DashboardInvitation params={params} />
+      <DashboardDeleteButton params={params} />
     </div>
   );
 }

--- a/src/components/dashboard/edits/DashboardDeleteButton.tsx
+++ b/src/components/dashboard/edits/DashboardDeleteButton.tsx
@@ -5,14 +5,14 @@ import Button from '@/components/commons/button';
 import Modal from '@/components/commons/modal';
 import { ContentModalState } from '@planit-types';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function DashboardDeleteButton({
   params,
 }: {
   params: { id: number };
 }) {
-  const route = useRouter();
+  const router = useRouter();
   const [modalState, setModalState] = useState<ContentModalState>({
     isOpen: false,
     message: '',
@@ -26,6 +26,9 @@ export default function DashboardDeleteButton({
   // 모달 닫기
   const handleClose = () => {
     setModalState({ ...modalState, isOpen: false });
+    if (!modalState.isContent) {
+      router.push('/mydashboard');
+    }
   };
 
   // 대시보드 삭제
@@ -33,9 +36,7 @@ export default function DashboardDeleteButton({
     // deleteDashboard API 호출
     await deleteDashboard(params.id.toString());
     setModalState({ isOpen: true, message: '대시보드가 삭제되었습니다.' });
-    route.push('/mydashboard');
   };
-
   return (
     <>
       <div className="mt-40 w-full max-w-320">

--- a/src/components/dashboard/edits/DashboardDeleteButton.tsx
+++ b/src/components/dashboard/edits/DashboardDeleteButton.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { deleteDashboard } from '@/app/api/dashboards';
+import Button from '@/components/commons/button';
+import Modal from '@/components/commons/modal';
+import { ContentModalState } from '@planit-types';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function DashboardDeleteButton({
+  params,
+}: {
+  params: { id: number };
+}) {
+  const route = useRouter();
+  const [modalState, setModalState] = useState<ContentModalState>({
+    isOpen: false,
+    message: '',
+  });
+
+  // 대시보드 삭제 모달 열기
+  const handleOpenDashboardDeleteModal = () => {
+    setModalState({ ...modalState, isOpen: true, isContent: true });
+  };
+
+  // 모달 닫기
+  const handleClose = () => {
+    setModalState({ ...modalState, isOpen: false });
+  };
+
+  // 대시보드 삭제
+  const handleDashboardDelete = async () => {
+    // deleteDashboard API 호출
+    await deleteDashboard(params.id.toString());
+    setModalState({ isOpen: true, message: '대시보드가 삭제되었습니다.' });
+    route.push('/mydashboard');
+  };
+
+  return (
+    <>
+      <div className="mt-40 w-full max-w-320">
+        <Button
+          text="대시보드 삭제하기"
+          onClick={handleOpenDashboardDeleteModal}
+          styles="w-full border border-gray-200 !bg-transparent !text-black-800 py-20"
+        />
+      </div>
+      <Modal isOpen={modalState.isOpen} onClose={handleClose}>
+        <div className="m-auto px-54 pb-29 pt-26 text-center text-18 md:w-540 md:px-33">
+          {modalState.isContent ? (
+            <div>
+              <p className="pb-47 pt-50">대시보드를 삭제하실건가요?</p>
+              <div className="flex justify-end gap-12">
+                <Button
+                  text="취소"
+                  onClick={handleClose}
+                  styles="border !border-gray-200 !bg-white px-30 py-8 text-14 !text-toss-blue"
+                />
+                <Button
+                  onClick={handleDashboardDelete}
+                  text="삭제"
+                  styles="px-30 py-8 text-14"
+                />
+              </div>
+            </div>
+          ) : (
+            <>
+              <p className="pb-47 pt-50 text-center">{modalState.message}</p>
+              <span className="flex justify-center md:justify-end">
+                <Button
+                  styles="w-138 h-42 md:w-120 md:h-48"
+                  text="확인"
+                  onClick={handleClose}
+                />
+              </span>
+            </>
+          )}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/dashboard/edits/DashboardInvitation.tsx
+++ b/src/components/dashboard/edits/DashboardInvitation.tsx
@@ -11,16 +11,10 @@ import Modal from '@/components/commons/modal';
 import { PAGE_SIZE } from '@/constants/globalConstants';
 import { emailValidationSchema } from '@/utils/validation/schema';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { EmailRequest, Invitation } from '@planit-types';
+import { ContentModalState, EmailRequest, Invitation } from '@planit-types';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-
-type ContentModalState = {
-  isOpen: boolean;
-  message: string;
-  isContent?: boolean;
-};
 
 export default function DashboardInvitation({
   params,

--- a/src/components/dashboard/edits/DashboardMember.tsx
+++ b/src/components/dashboard/edits/DashboardMember.tsx
@@ -113,6 +113,7 @@ export default function DashboardMember({
               alt="arrow_next"
               width={8}
               height={13}
+              className="fill-gray-300"
             />
           </button>
         </div>


### PR DESCRIPTION
## ✨ Done
- [x] 대시보드 삭제 기능

## ✅ 주요 변경사항
- 정말 대시보드를 삭제하겠냐는 모달이 뜨고 삭제를 클릭하면 대시보드 삭제 후 마이 대시보드 페이지로 이동합니다. 

## 📸 스크린샷
<img width="650" alt="image" src="https://github.com/13teamProject/Planit/assets/50002974/8598b308-29c2-4153-ba26-70ef0e162e8e">
<img width="1073" alt="image" src="https://github.com/13teamProject/Planit/assets/50002974/8a3e3436-0c08-4a9e-9aa4-fd2857a4d91d">
