### PR TITLE
[#89] Tag Color 랜덤 적용

### DIFF
--- a/src/components/commons/input/TagInput.tsx
+++ b/src/components/commons/input/TagInput.tsx
@@ -99,14 +99,11 @@ function TagInput({ onChange, defaultValue, ...args }: TagInputProps) {
           {[...tagList].reverse().map((tag: string) => (
             <Tag
               key={tag}
-              size="lg"
-              color="toss"
+              text={tag}
               deleteTag={() => {
                 filterTagList(tag);
               }}
-            >
-              {tag}
-            </Tag>
+            />
           ))}
         </div>
       )}

--- a/src/components/commons/tag/index.tsx
+++ b/src/components/commons/tag/index.tsx
@@ -1,41 +1,43 @@
 'use client';
 
-import classNames from 'classnames';
+import { getTagColor } from '@/utils/color';
 import Image from 'next/image';
-import { ReactNode } from 'react';
 
-type TagProps = {
-  color: string;
-  size: 'lg' | 'sm';
-  round?: boolean;
-  children: ReactNode;
+import ColorCircle from '../circle/ColorCircle';
+
+type RoundTagProps = {
+  type: 'round';
+  text: string;
+};
+
+type DefalutTagProps = {
+  type?: 'default';
+  text: string;
   deleteTag?: () => void;
 };
 
-export default function Tag({
-  color,
-  round,
-  size,
-  deleteTag,
-  children,
-}: TagProps) {
-  const roundClass = round ? 'rounded-full' : 'rounded';
-  const colorVariants: { [key: string]: string } = {
-    toss: 'bg-toss-blue-light text-toss-blue',
-    blue: 'bg-blue-light-chip text-blue-chip',
-    green: 'bg-green-light-chip text-green-chip',
-    orange: 'bg-orange-light-chip text-orange-chip',
-    pink: 'bg-pink-light-chip text-pink-chip',
-    red: 'bg-red-light-chip text-red-chip',
-    purple: 'bg-purple-light-chip text-purple-chip',
-  };
-  const sizeClass = classNames(
-    'text-12 inline-flex items-center rounded px-8 py-4 max-w-full',
-    {
-      'text-12': size === 'lg',
-      'text-10': size === 'sm',
-    },
+export default function Tag(props: RoundTagProps | DefalutTagProps) {
+  const { type = 'default', text } = props;
+
+  if (type === 'round') return <RoundTag text={text} />;
+
+  const { deleteTag } = props as DefalutTagProps;
+  return <DefaultTag text={text} deleteTag={deleteTag} />;
+}
+
+function RoundTag({ text }: { text: string }) {
+  return (
+    <span className="inline-flex max-w-full items-center rounded-full bg-toss-blue-light px-8 py-4 text-10 text-toss-blue md:text-12">
+      <div className="md:gap-4-4 flex items-center gap-3">
+        <ColorCircle size="xs" color="bg-toss-blue" />
+        {text}
+      </div>
+    </span>
   );
+}
+
+function DefaultTag({ text, deleteTag }: Omit<DefalutTagProps, 'type'>) {
+  const tagColor = getTagColor(text);
 
   if (deleteTag) {
     return (
@@ -43,9 +45,9 @@ export default function Tag({
         type="button"
         onClick={deleteTag}
         tabIndex={0}
-        className={`${colorVariants[color]} ${roundClass} ${sizeClass} group/tag relative`}
+        className={`group/tag relative inline-flex max-w-full items-center rounded px-8 py-4 text-12 md:text-12 ${tagColor}`}
       >
-        {children}
+        {text}
         <div className="invisible absolute inset-0 flex items-center justify-center rounded bg-[#f5f5f5] bg-opacity-80 outline-none group-hover/tag:visible">
           <Image
             src="/icon/close_red.svg"
@@ -60,8 +62,10 @@ export default function Tag({
   }
 
   return (
-    <span className={`${colorVariants[color]} ${roundClass} ${sizeClass}`}>
-      {children}
+    <span
+      className={`inline-flex max-w-full items-center rounded px-8 py-4 text-12 md:text-12 ${tagColor}`}
+    >
+      {text}
     </span>
   );
 }

--- a/src/components/dashboard/cards/Card.tsx
+++ b/src/components/dashboard/cards/Card.tsx
@@ -51,9 +51,7 @@ export default function Card({ cardId, columnTitle }: CardProps) {
           <div className="md:flex md:w-full md:gap-16 lg:block">
             <div className="flex flex-wrap gap-6">
               {card.tags.map((tag) => (
-                <Tag key={tag} color="green" size="sm">
-                  {tag}
-                </Tag>
+                <Tag key={tag} text={tag} />
               ))}
             </div>
             <div className="flex flex-grow items-baseline justify-between pt-8">

--- a/src/components/dashboard/cards/EditCardModal.tsx
+++ b/src/components/dashboard/cards/EditCardModal.tsx
@@ -4,7 +4,6 @@ import { editCard, postCardImage } from '@/app/api/cards-goni';
 import { getColumns } from '@/app/api/columns';
 import { getMembers } from '@/app/api/members';
 import Button from '@/components/commons/button';
-import ColorCircle from '@/components/commons/circle/ColorCircle';
 import ProfileCircle from '@/components/commons/circle/ProfileCircle';
 import Input from '@/components/commons/input';
 import DateInput from '@/components/commons/input/DateInput';
@@ -160,22 +159,12 @@ export default function EditCardModal({
                 name="columnId"
                 control={control}
                 defaultValue={
-                  <Tag round color="orange" size="sm">
-                    <div className="md:gap-4-4 flex items-center gap-3">
-                      <ColorCircle size="xs" color="bg-orange-dashboard" />
-                      {currentStatus?.title}
-                    </div>
-                  </Tag>
+                  <Tag type="round" text={currentStatus?.title as string} />
                 }
               >
                 {statusList.map((status) => (
                   <DropdownInput.Option key={status.id} id={status.id}>
-                    <Tag round color="orange" size="sm">
-                      <div className="md:gap-4-4 flex items-center gap-3">
-                        <ColorCircle size="xs" color="bg-orange-dashboard" />
-                        {status.title}
-                      </div>
-                    </Tag>
+                    <Tag type="round" text={status.title} />
                   </DropdownInput.Option>
                 ))}
               </DropdownInput>

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-bitwise */
+
+function stringToColor(str: string, predefinedColors: string[]) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  hash = (hash * 0x45d9f3b) ^ (hash >> 16);
+
+  const index = Math.abs(hash % predefinedColors.length);
+  return predefinedColors[index];
+}
+
+const TAG_COLORS = [
+  'bg-zinc-900 text-gray-50',
+  'bg-gray-200 text-zinc-900',
+  'bg-pink-light-chip text-pink-chip',
+  'bg-red-light-chip text-red-chip',
+  'bg-orange-light-chip text-orange-chip',
+  'bg-yellow-300 text-yellow-600',
+  'bg-green-light-chip text-green-chip',
+  'bg-emerald-300 text-emerald-600',
+  'bg-teal-300 text-teal-600',
+  'bg-cyan-300 text-cyan-600',
+  'bg-toss-blue-light text-toss-blue',
+  'bg-blue-light-chip text-blue-chip',
+  'bg-indigo-300 text-indigo-600',
+  'bg-purple-light-chip text-purple-chip',
+  'bg-violet-300 text-violet-600',
+];
+
+export function getTagColor(str: string) {
+  return stringToColor(str, TAG_COLORS);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,40 @@ const createPxMap = (size: number): Record<string, string> =>
 const PX_10 = createPxMap(10);
 const PX_100 = createPxMap(100);
 const PX_2000 = createPxMap(2000);
+
+const RANDOM_TAG_COLORS = [
+  'bg-zinc-900',
+  'text-gray-50',
+  'bg-gray-200',
+  'text-zinc-900',
+  'bg-pink-light-chip',
+  'text-pink-chip',
+  'bg-red-light-chip',
+  'text-red-chip',
+  'bg-orange-light-chip',
+  'text-orange-chip',
+  'bg-yellow-300',
+  'text-yellow-600',
+  'bg-green-light-chip',
+  'text-green-chip',
+  'bg-emerald-300',
+  'text-emerald-600',
+  'bg-teal-300',
+  'text-teal-600',
+  'bg-cyan-300',
+  'text-cyan-600',
+  'bg-toss-blue-light',
+  'text-toss-blue',
+  'bg-blue-light-chip',
+  'text-blue-chip',
+  'bg-indigo-300',
+  'text-indigo-600',
+  'bg-purple-light-chip',
+  'text-purple-chip',
+  'bg-violet-300',
+  'text-violet-600',
+];
+
 const config: Config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -19,6 +53,7 @@ const config: Config = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     './node_modules/react-tailwindcss-datepicker/dist/index.esm.js',
   ],
+  safelist: RANDOM_TAG_COLORS,
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## ✨ Done

- [x] Tag Color 랜덤 적용

## ✅ 주요 변경사항

- Tag 컴포넌트 변경 있습니다.
### 변경 후 사용 방법
```tsx
// 기본 태그
<Tag text="프론트엔드" />
```

```tsx
// 라운드 태그
<Tag type="round" text="To Do" />
```
- Tailwind 동적 클래스 적용을 위해서 safelist 적용했습니다.
참고자료: https://velog.io/@arthur/Tailwind-CSS-%EC%97%90%EC%84%9C-%EB%8F%99%EC%A0%81%EC%9C%BC%EB%A1%9C-%ED%81%B4%EB%9E%98%EC%8A%A4-%ED%95%A0%EB%8B%B9%ED%95%98%EA%B8%B0

## 📸 스크린샷

- 장점: 특정 문자열에 대해 언제나 고유한 색상을 가집니다.

https://github.com/13teamProject/Planit/assets/102004889/1af6a9d5-5b6b-4a7e-8537-e7424c22b300



- 단점: 색상이 겹칠 수 있습니다

https://github.com/13teamProject/Planit/assets/102004889/862e2609-21d9-41e8-9ca8-6c0cb6b74414



