### PR TITLE
[#112] dashboardHeader 수정

### DIFF
--- a/src/app/(dashboard)/dashboard/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/[id]/page.tsx
@@ -6,7 +6,7 @@ import DashBoardHeader from '@/components/commons/layout/DashboardHeader';
 import Sidemenu from '@/components/commons/layout/Sidemenu';
 import Column from '@/components/dashboard/Column';
 import { GetDashboardIdResponse } from '@planit-types';
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 
 export default function DashboardPage({
   params,
@@ -41,7 +41,9 @@ export default function DashboardPage({
     <div className="flex h-screen lg:overflow-hidden">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
-        <DashBoardHeader isDashboard />
+        <Suspense>
+          <DashBoardHeader isDashboard params={params} />
+        </Suspense>
         <div className="w-full bg-gray-50 lg:flex lg:h-full lg:overflow-hidden">
           <Column key={dashboard.id} dashboardId={dashboard.id} />
           <div className="sm:w-full sm:p-12 md:w-full md:p-20 lg:w-500">

--- a/src/app/(dashboard)/edit/[id]/layout.tsx
+++ b/src/app/(dashboard)/edit/[id]/layout.tsx
@@ -6,16 +6,16 @@ import { Suspense } from 'react';
 
 export default function Layout({
   children,
+  params,
 }: Readonly<{
   children: React.ReactNode;
+  params: { id: number };
 }>) {
   return (
     <div className="flex h-screen">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
-        <Suspense>
-          <DashBoardHeader isDashboard />
-        </Suspense>
+        <DashBoardHeader params={params} isDashboard />
         <div className="flex-1 bg-gray-50 p-20">{children}</div>
       </div>
     </div>

--- a/src/app/(dashboard)/edit/[id]/layout.tsx
+++ b/src/app/(dashboard)/edit/[id]/layout.tsx
@@ -15,7 +15,9 @@ export default function Layout({
     <div className="flex h-screen">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
-        <DashBoardHeader params={params} isDashboard />
+        <Suspense>
+          <DashBoardHeader params={params} isDashboard />
+        </Suspense>
         <div className="flex-1 bg-gray-50 p-20">{children}</div>
       </div>
     </div>

--- a/src/app/(dashboard)/mydashboard/page.tsx
+++ b/src/app/(dashboard)/mydashboard/page.tsx
@@ -6,13 +6,17 @@ import InviteDashboard from '@/components/mydashboard/InviteDashboard';
 import NewDashboard from '@/components/mydashboard/NewDashboard';
 import { Suspense } from 'react';
 
-export default function MyDashBoardPage() {
+export default function MyDashBoardPage({
+  params,
+}: {
+  params: { id: number };
+}) {
   return (
     <div className="flex h-screen bg-gray-50">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
         <Suspense>
-          <DashBoardHeader isDashboard={false} />
+          <DashBoardHeader isDashboard={false} params={params} />
         </Suspense>
         <div className="no-scrollbar flex-1 overflow-auto">
           <NewDashboard />

--- a/src/app/(dashboard)/mydashboard/page.tsx
+++ b/src/app/(dashboard)/mydashboard/page.tsx
@@ -6,17 +6,13 @@ import InviteDashboard from '@/components/mydashboard/InviteDashboard';
 import NewDashboard from '@/components/mydashboard/NewDashboard';
 import { Suspense } from 'react';
 
-export default function MyDashBoardPage({
-  params,
-}: {
-  params: { id: number };
-}) {
+export default function MyDashBoardPage() {
   return (
     <div className="flex h-screen bg-gray-50">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
         <Suspense>
-          <DashBoardHeader isDashboard={false} params={params} />
+          <DashBoardHeader isDashboard={false} />
         </Suspense>
         <div className="no-scrollbar flex-1 overflow-auto">
           <NewDashboard />

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -6,15 +6,17 @@ import { Suspense } from 'react';
 
 export default function Layout({
   children,
+  params,
 }: Readonly<{
   children: React.ReactNode;
+  params: { id: number };
 }>) {
   return (
     <div className="flex h-screen">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
         <Suspense>
-          <DashBoardHeader isDashboard />
+          <DashBoardHeader isDashboard={false} params={params} />
         </Suspense>
         <div className="flex-1 bg-gray-50 p-20">{children}</div>
       </div>

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -6,17 +6,15 @@ import { Suspense } from 'react';
 
 export default function Layout({
   children,
-  params,
 }: Readonly<{
   children: React.ReactNode;
-  params: { id: number };
 }>) {
   return (
     <div className="flex h-screen">
       <Sidemenu />
       <div className="flex flex-1 flex-col">
         <Suspense>
-          <DashBoardHeader isDashboard={false} params={params} />
+          <DashBoardHeader isDashboard={false} />
         </Suspense>
         <div className="flex-1 bg-gray-50 p-20">{children}</div>
       </div>

--- a/src/components/commons/layout/DashboardHeader.tsx
+++ b/src/components/commons/layout/DashboardHeader.tsx
@@ -32,7 +32,7 @@ export default function DashBoardHeader({
   params,
 }: {
   isDashboard: boolean;
-  params: { id: number };
+  params?: { id: number };
 }) {
   const router = useRouter();
   const { userInfo } = useAuthStore();
@@ -43,7 +43,7 @@ export default function DashBoardHeader({
   const [maxVisible, setMaxVisible] = useState(4);
   const [isExpanded, setIsExpanded] = useState(false);
   const [dashboards, setDashboards] = useState<Dashboard>();
-  const [selectedDashboardId] = useState<number>(params.id);
+  const [selectedDashboardId] = useState<number>(params ? params.id : 0);
   const [members, setMembers] = useState<Member[]>([]);
   const [isClient, setIsClient] = useState(false);
   const { dashboardName, setData } = useDashboardNameChange();
@@ -95,7 +95,6 @@ export default function DashBoardHeader({
   // 멤버 목록 조회
   const fetchMembers = async () => {
     if (!selectedDashboardId) return;
-
     const response = await getMembers({
       dashboardId: selectedDashboardId,
     });
@@ -233,7 +232,7 @@ export default function DashBoardHeader({
             <>
               <div className="flex font-semibold">
                 {visibleProfiles.map((profile) => (
-                  <li key={profile.id} className="-mr-1">
+                  <li key={profile.id} className="-mr-6">
                     <ProfileCircle
                       data={{
                         nickname: profile.nickname[0],

--- a/src/components/commons/layout/DashboardHeader.tsx
+++ b/src/components/commons/layout/DashboardHeader.tsx
@@ -174,17 +174,15 @@ export default function DashBoardHeader({
                 {dashboardName}
               </p>
             )}
-            {isClient &&
-              dashboards?.createdByMe &&
-              !window.location.pathname.startsWith('/edit') && (
-                <Image
-                  className="sm:hidden lg:block"
-                  src="/icon/crown.svg"
-                  width={20}
-                  height={20}
-                  alt="내가 만든 대시보드 표시"
-                />
-              )}
+            {isClient && dashboards?.createdByMe && (
+              <Image
+                className="sm:hidden lg:block"
+                src="/icon/crown.svg"
+                width={20}
+                height={20}
+                alt="내가 만든 대시보드 표시"
+              />
+            )}
           </div>
         )}
 

--- a/src/components/commons/layout/DashboardHeader.tsx
+++ b/src/components/commons/layout/DashboardHeader.tsx
@@ -1,34 +1,25 @@
 'use client';
 
-import {
-  getDashboardInvitation,
-  getDashboards,
-  postInvitation,
-} from '@/app/api/dashboards';
+import { getDashboradDetail, postInvitation } from '@/app/api/dashboards';
 import { getMembers } from '@/app/api/members';
-import { getUsers } from '@/app/api/users';
 import Button from '@/components/commons/button';
 import DropDownSelectBox from '@/components/commons/dropdown';
 import Input from '@/components/commons/input';
 import Modal from '@/components/commons/modal';
-import { PAGE_SIZE, SCROLL_SIZE } from '@/constants/globalConstants';
 import { handleLogout } from '@/service/authService';
+import { useAuthStore } from '@/store/authStore';
+import { useDashboardNameChange } from '@/store/dashBoardName';
 import { emailValidationSchema } from '@/utils/validation/schema';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Dashboard, EmailRequest, Invitation, Member } from '@planit-types';
+import { Dashboard, EmailRequest, Member } from '@planit-types';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-toastify';
 
 import ProfileCircle from '../circle/ProfileCircle';
-
-type User = {
-  id: number;
-  nickname: string;
-  profileImageUrl: string | null;
-};
 
 type ContentModalState = {
   isOpen: boolean;
@@ -38,52 +29,42 @@ type ContentModalState = {
 
 export default function DashBoardHeader({
   isDashboard,
+  params,
 }: {
   isDashboard: boolean;
+  params: { id: number };
 }) {
+  const router = useRouter();
+  const { userInfo } = useAuthStore();
+  const resolver = yupResolver(emailValidationSchema);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  // state
+  const [selectBoxIsOpen, setSelectBoxIsOpen] = useState(false);
   const [maxVisible, setMaxVisible] = useState(4);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [dashboardDetails, setDashboardDetails] = useState<Dashboard | null>(
-    null,
-  );
-  const [dashboards, setDashboards] = useState<Dashboard[]>([]);
-  const [selectedDashboardId, setSelectedDashboardId] = useState<number | null>(
-    null,
-  );
-  const [user, setUser] = useState<User | null>(null);
+  const [dashboards, setDashboards] = useState<Dashboard>();
+  const [selectedDashboardId] = useState<number>(params.id);
   const [members, setMembers] = useState<Member[]>([]);
+  const [isClient, setIsClient] = useState(false);
+  const { dashboardName, setData } = useDashboardNameChange();
   const [modalState, setModalState] = useState<ContentModalState>({
     isOpen: false,
     message: '',
   });
-  const resolver = yupResolver(emailValidationSchema);
-  const [invitationData, setInvitaionData] = useState<Invitation[]>([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<EmailRequest>({ resolver, mode: 'onChange' });
-  const [isClient, setIsClient] = useState(false);
-  const { id } = useParams();
-  const [selectBoxIsOpen, setSelectBoxIsOpen] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const router = useRouter();
 
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
+  // 대시보드 정보 불러오기
   const fetchDashboards = async () => {
-    const response = await getDashboards('pagination', 1, SCROLL_SIZE);
-    setDashboards(response.dashboards);
-    const currentDashboard = response.dashboards.find(
-      (dashboard) => dashboard.id === Number(id),
-    );
-    if (currentDashboard) {
-      setSelectedDashboardId(currentDashboard.id);
-      setDashboardDetails(currentDashboard);
+    const response = await getDashboradDetail(selectedDashboardId);
+    if ('message' in response) {
+      toast.error(response.message);
+    } else {
+      setDashboards(response);
+      setData(response.title);
     }
   };
 
@@ -92,69 +73,70 @@ export default function DashBoardHeader({
     setModalState({ ...modalState, isOpen: false });
   };
 
-  // 초대 내역 조회
-  const fetchDashboardInvitation = async (page: number) => {
-    if (!selectedDashboardId) return;
-    try {
-      const fetchedDashboardInvitation = await getDashboardInvitation({
-        dashboardId: selectedDashboardId,
-        page,
-        size: PAGE_SIZE,
-      });
-      if ('message' in fetchedDashboardInvitation) {
-        console.error(fetchedDashboardInvitation.message);
-      } else {
-        setInvitaionData(fetchedDashboardInvitation.invitations);
-        setTotalPages(
-          Math.ceil(fetchedDashboardInvitation.totalCount / PAGE_SIZE),
-        );
-      }
-    } catch (error) {
-      console.error('Failed to fetch dashboard invitations:', error);
-    }
-  };
-
   // 초대하기 모달 열기
   const handleOpenInvitation = async () => {
     setModalState({ ...modalState, isOpen: true, isContent: true });
-    await fetchDashboardInvitation(currentPage);
-  };
-
-  // 멤버 목록 조회
-  const fetchMembers = async () => {
-    if (!selectedDashboardId) return;
-    const response = await getMembers({
-      dashboardId: selectedDashboardId,
-    });
-    if ('message' in response) {
-      console.error(response.message);
-    } else {
-      setMembers(response.members);
-    }
   };
 
   // 초대하기
   const onSubmit: SubmitHandler<EmailRequest> = async (email) => {
     if (!selectedDashboardId) return;
+
     const response = await postInvitation(email, selectedDashboardId);
+
     if ('message' in response) {
-      setModalState({ isOpen: true, message: response.message });
+      toast.error(response.message);
     } else {
-      setModalState({ isOpen: true, message: '초대가 완료되었습니다.' });
-      await fetchDashboardInvitation(currentPage);
+      toast.success('초대가 완료되었습니다.');
+      handleClose();
     }
   };
 
-  useEffect(() => {
-    if (id) {
-      fetchDashboards();
-    }
-  }, [id]);
+  // 멤버 목록 조회
+  const fetchMembers = async () => {
+    if (!selectedDashboardId) return;
 
+    const response = await getMembers({
+      dashboardId: selectedDashboardId,
+    });
+    if ('message' in response) {
+      toast.error(response.message);
+    } else {
+      setMembers(response.members);
+    }
+  };
+
+  // Profile Circle toggle
+  const toggleProfiles = () => {
+    if (window.innerWidth >= 1200) {
+      setIsExpanded(!isExpanded);
+      setMaxVisible(!isExpanded ? members.length : 4);
+    }
+  };
+
+  const visibleProfiles = members.slice(0, maxVisible);
+  const extraCount = members.length - maxVisible;
+  const logoutUser = () => {
+    handleLogout();
+    router.push('/');
+  };
+
+  const dropdownList = [
+    {
+      label: '마이페이지',
+      onClick: () => {
+        router.push('/mypage');
+      },
+    },
+    { label: '로그아웃', onClick: logoutUser },
+  ];
   useEffect(() => {
-    fetchDashboardInvitation(currentPage);
-    fetchMembers();
-  }, [currentPage, selectedDashboardId]);
+    if (isDashboard) {
+      fetchDashboards();
+      fetchMembers();
+    }
+    setIsClient(true);
+  }, [selectedDashboardId]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -175,60 +157,25 @@ export default function DashBoardHeader({
     };
   }, [isExpanded, members.length]);
 
-  useEffect(() => {
-    async function fetchUser() {
-      try {
-        const userData = await getUsers();
-        setUser(userData);
-      } catch (error) {
-        console.error('Failed to fetch user:', error);
-      }
-    }
-
-    fetchUser();
-  }, []);
-
-  // Profile Circle toggle
-  const toggleProfiles = () => {
-    if (window.innerWidth >= 1200) {
-      setIsExpanded(!isExpanded);
-      setMaxVisible(!isExpanded ? members.length : 4);
-    }
-  };
-
-  const visibleProfiles = members.slice(0, maxVisible);
-  const extraCount = members.length - maxVisible;
-
-  const logoutUser = () => {
-    handleLogout();
-    router.push('/');
-  };
-
-  const dropdownList = [
-    {
-      label: '마이페이지',
-      onClick: () => {
-        router.push('/mypage');
-      },
-    },
-    { label: '로그아웃', onClick: logoutUser },
-  ];
-
   return (
     <>
       <nav className="right-0 top-0 z-[998] flex h-70 w-full items-center justify-end border-1 border-l-0 border-b-gray-200 bg-white py-25 pr-12 md:pr-40 lg:justify-between lg:pe-80 lg:ps-40">
-        {!isDashboard && (
-          <p className="text-20 font-bold sm:hidden lg:block">내 대시보드</p>
+        {!isDashboard && isClient && (
+          <p className="text-20 font-bold sm:hidden lg:block">
+            {window.location.pathname.startsWith('/mypage')
+              ? '계정 관리'
+              : '내 대시보드'}
+          </p>
         )}
         {isDashboard && (
           <div className="flex">
-            <p className="mr-8 text-20 font-bold sm:hidden lg:block">
-              {isClient && window.location.pathname.startsWith('/edit')
-                ? '계정 관리'
-                : dashboardDetails?.title}
-            </p>
+            {isClient && (
+              <p className="mr-8 text-20 font-bold sm:hidden lg:block">
+                {dashboardName}
+              </p>
+            )}
             {isClient &&
-              dashboardDetails?.createdByMe &&
+              dashboards?.createdByMe &&
               !window.location.pathname.startsWith('/edit') && (
                 <Image
                   className="sm:hidden lg:block"
@@ -240,78 +187,84 @@ export default function DashBoardHeader({
               )}
           </div>
         )}
+
         <ul className="flex items-center">
-          {isDashboard && dashboardDetails?.createdByMe && (
-            <li className="pl-12">
-              <Link href={`/edit/${selectedDashboardId}`}>
+          {isDashboard &&
+            dashboards?.createdByMe &&
+            !window.location.pathname.startsWith('/edit') && (
+              //
+              <li className="pl-12">
+                <Link href={`/edit/${selectedDashboardId}`}>
+                  <button
+                    type="button"
+                    className="flex h-40 w-88 items-center justify-center rounded-8 border-1 border-gray-200 text-16 font-medium text-gray-400 hover:border-black-700"
+                  >
+                    <Image
+                      src="/icon/settings.svg"
+                      className="mr-8 sm:hidden md:block lg:block"
+                      width={20}
+                      height={20}
+                      alt="관리 아이콘"
+                    />
+                    관리
+                  </button>
+                </Link>
+              </li>
+            )}
+          {isDashboard &&
+            dashboards?.createdByMe &&
+            !window.location.pathname.startsWith('/edit') && (
+              <li>
                 <button
                   type="button"
-                  className="flex h-40 w-88 items-center justify-center rounded-8 border-1 border-gray-200 text-16 font-medium text-gray-400 hover:border-black-700"
+                  className="ml-16 mr-16 flex h-40 w-116 items-center justify-center rounded-8 border-1 border-gray-200 text-16 font-medium text-gray-400 hover:border-black-700 md:mr-32 lg:mr-40"
+                  onClick={handleOpenInvitation}
                 >
                   <Image
-                    src="/icon/settings.svg"
+                    src="/icon/add_box.svg"
                     className="mr-8 sm:hidden md:block lg:block"
                     width={20}
                     height={20}
-                    alt="관리 아이콘"
+                    alt="초대하기 아이콘"
                   />
-                  관리
+                  초대하기
                 </button>
-              </Link>
-            </li>
-          )}
-          {isDashboard && (
-            <li>
-              <button
-                type="button"
-                className="ml-16 mr-16 flex h-40 w-116 items-center justify-center rounded-8 border-1 border-gray-200 text-16 font-medium text-gray-400 hover:border-black-700 md:mr-32 lg:mr-40"
-                onClick={handleOpenInvitation}
-              >
-                <Image
-                  src="/icon/add_box.svg"
-                  className="mr-8 sm:hidden md:block lg:block"
-                  width={20}
-                  height={20}
-                  alt="초대하기 아이콘"
-                />
-                초대하기
-              </button>
-            </li>
-          )}
-          {isDashboard && (
-            <div className="flex font-semibold">
-              {visibleProfiles.map((profile) => (
-                <li key={profile.id} className="-mr-1">
-                  <ProfileCircle
-                    data={{
-                      nickname: profile.nickname[0],
-                      profileImageUrl: profile.profileImageUrl,
+              </li>
+            )}
+          {isDashboard && !dashboards?.createdByMe && (
+            <>
+              <div className="flex font-semibold">
+                {visibleProfiles.map((profile) => (
+                  <li key={profile.id} className="-mr-1">
+                    <ProfileCircle
+                      data={{
+                        nickname: profile.nickname[0],
+                        profileImageUrl: profile.profileImageUrl,
+                      }}
+                      styles="size-34 md:size-38 bg-orange-400"
+                    />
+                  </li>
+                ))}
+                {extraCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={toggleProfiles}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        toggleProfiles();
+                      }
                     }}
-                    styles="size-34 md:size-38 bg-orange-400"
-                  />
-                </li>
-              ))}
-              {extraCount > 0 && (
-                <button
-                  type="button"
-                  onClick={toggleProfiles}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      toggleProfiles();
-                    }
-                  }}
-                  className="focus:outline-none"
-                  aria-label="프로필 추가 버튼"
-                >
-                  <div className="flex size-34 transform cursor-pointer items-center justify-center rounded-full bg-pink-400 text-white ring-2 ring-white transition-transform duration-200 ease-in-out hover:scale-110 md:size-38">
-                    +{extraCount}
-                  </div>
-                </button>
-              )}
-            </div>
-          )}
-          {isDashboard && (
-            <div className="mx-12 h-38 border-l border-gray-200 md:mx-24 lg:mx-32" />
+                    className="focus:outline-none"
+                    aria-label="프로필 추가 버튼"
+                  >
+                    <div className="flex size-34 transform cursor-pointer items-center justify-center rounded-full bg-pink-400 text-white ring-2 ring-white transition-transform duration-200 ease-in-out hover:scale-110 md:size-38">
+                      +{extraCount}
+                    </div>
+                  </button>
+                )}
+              </div>
+              <div className="mx-12 h-38 border-l border-gray-200 md:mx-24 lg:mx-32" />
+            </>
           )}
           <button
             ref={buttonRef}
@@ -322,16 +275,16 @@ export default function DashBoardHeader({
             <li className="font-semibold">
               <ProfileCircle
                 data={{
-                  nickname: user?.nickname[0] || '',
-                  profileImageUrl: user?.profileImageUrl || null,
+                  nickname: userInfo?.nickname[0] || '',
+                  profileImageUrl: userInfo?.profileImageUrl || null,
                 }}
                 styles="size-34 md:size-38 bg-violet-dashboard"
               />
             </li>
             <li className="pl-12">
-              {user && (
+              {userInfo && (
                 <p className="text-16 font-medium sm:hidden md:block lg:block">
-                  {user.nickname}
+                  {userInfo.nickname}
                 </p>
               )}
             </li>
@@ -348,53 +301,43 @@ export default function DashBoardHeader({
           </button>
         </ul>
       </nav>
+
       <Modal isOpen={modalState.isOpen} onClose={handleClose}>
-        <div className="m-auto px-54 pb-29 pt-26 text-right text-18 md:w-540 md:px-33">
-          {modalState.isContent ? (
-            <div className="text-left">
-              <h3 className="mb-30 text-24 font-bold">초대하기</h3>
-              <p className="mb-10 text-18">이메일</p>
-              <form onSubmit={handleSubmit(onSubmit)}>
-                <Input
-                  id="email"
-                  type="text"
-                  placeholder="이메일을 입력해 주세요"
-                  size="lg"
-                  register={{ ...register('email', { required: true }) }}
-                  defaultValue="" // 기본값 설정
-                  error={'email' in errors}
-                />
-                {errors.email && (
-                  <span className="pt-8 text-14 text-red-500">
-                    {errors.email.message}
-                  </span>
-                )}
-                <div className="mt-28 flex justify-end gap-12">
-                  <Button
-                    text="취소"
-                    onClick={handleClose}
-                    styles="border !border-gray-200 !bg-white px-30 py-8 text-14 !text-toss-blue"
-                  />
-                  <Button
-                    type="submit"
-                    text="초대"
-                    styles="px-30 py-8 text-14"
-                  />
-                </div>
-              </form>
-            </div>
-          ) : (
-            <>
-              <p className="pb-47 pt-50 text-center">{modalState.message}</p>
-              <span className="flex justify-center md:justify-end">
-                <Button
-                  styles="w-138 h-42 md:w-120 md:h-48"
-                  text="확인"
-                  onClick={handleClose}
-                />
+        <div className="m-auto w-330 px-20 pb-29 pt-26 text-right text-18 md:w-540 md:px-33">
+          <div className="text-left">
+            <h3 className="mb-24 text-20 font-bold md:mb-30 md:text-24">
+              초대하기
+            </h3>
+            <p className="mb-10 text-16 md:text-18">이메일</p>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <Input
+                id="email"
+                type="text"
+                placeholder="이메일을 입력해 주세요"
+                size="lg"
+                register={{ ...register('email', { required: true }) }}
+                error={'email' in errors}
+              />
+              <span
+                className={`pt-8 text-14 text-red-500 ${errors.email?.message ? 'block' : 'hidden'}`}
+              >
+                {errors.email?.message}
               </span>
-            </>
-          )}
+              <div className="mt-24 flex justify-end gap-12 md:mt-28">
+                <Button
+                  text="취소"
+                  onClick={handleClose}
+                  styles="border !border-gray-200 !bg-white basis-1/2 md:basis-auto px-30 py-8 text-14 !text-toss-blue"
+                />
+                <Button
+                  type="submit"
+                  text="초대"
+                  disabled={!isValid}
+                  styles="px-30 py-8 text-14  basis-1/2 md:basis-auto "
+                />
+              </div>
+            </form>
+          </div>
         </div>
       </Modal>
     </>

--- a/src/components/editdashboard/DashboardName.tsx
+++ b/src/components/editdashboard/DashboardName.tsx
@@ -4,6 +4,7 @@ import { getDashboradDetail, updateDashboard } from '@/app/api/dashboards';
 import Button from '@/components/commons/button';
 import ColorCircle from '@/components/commons/circle/ColorCircle';
 import Input from '@/components/commons/input';
+import { useDashboardNameChange } from '@/store/dashBoardName';
 import {
   ColorMapping,
   DashboardEditRequest,
@@ -23,6 +24,7 @@ export default function DashboardName({ params }: { params: { id: number } }) {
   } = useForm<DashboardEditRequest>();
   const [selectedColor, setSelectedColor] = useState<string>();
   const [dashboardData, setDashboardData] = useState<DashboardEditResponse>();
+  const { setData } = useDashboardNameChange();
 
   const colorMapping: ColorMapping = {
     '#5534DA': 'bg-violet-dashboard',
@@ -44,11 +46,11 @@ export default function DashboardName({ params }: { params: { id: number } }) {
       const editRequest = { ...data, color: selectedColor };
 
       const result = await updateDashboard(params.id, editRequest);
-
       if ('message' in result) {
         toast.error(result.message);
       } else {
         toast.success('대시보드 정보를 수정했습니다');
+        setData(result.title);
         setDashboardData(result);
         reset();
       }

--- a/src/store/dashBoardName.ts
+++ b/src/store/dashBoardName.ts
@@ -1,0 +1,20 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type NameState = {
+  dashboardName: string | null;
+  setData: (newName: string) => void;
+};
+
+export const useDashboardNameChange = create<NameState>()(
+  persist(
+    (set) => ({
+      dashboardName: null,
+      setData: (newName) => set({ dashboardName: newName }),
+    }),
+    {
+      name: 'dashboard-name', // 로컬 스토리지에 저장될 키 이름
+      getStorage: () => localStorage, // 스토리지 유형 지정
+    },
+  ),
+);


### PR DESCRIPTION
## ✨ Done
- [x] 프로필 사진/ 프로필 닉네임 수정시 새로고침 해야 헤더에 반영
- [x] 프로필 이미지 호버시 닉네임 보이게 (근데 좀 오래 호버해야 나와요 ㅎ)  
- [x] 대시보드 관리에서 계정관리가 뜸 → 대시보드 이름이 나와야 함
- [x] 계정관리에서 초대하기 버튼 안보이게
- [x] 헤더의 프로필 circle 여러개 있는 부분에 초대받은 사람만 보이게
- [x] 대시보드 이름 수정시 헤더에 반영
- [x] 헤더에서 초대했을때 초대 내역에 반영 안됨
   → 생각해보니 이미 관리 페이지인데 관리, 초대하기 버튼이 나오는게 이상해서 뺐습니다.
- [x] 대시보드 생성자만 초대하기 버튼 활성화

## ✅ 주요 변경사항
- 사용하지 않는 state들 정리했습니다.
- user 정보를 가져오는 함수를 삭제하고 localstorage에 있는 정보를 사용했습니다.
- 리스폰스 결과를 console.log -> toast로 변경했습니다.
- useEffect 사용 빈도를 줄였습니다.
- 프로필 이미지 좀 더 많이 겹치게 해봤습니다
- 바뀐게 많아서 사용해보시고 에러나는 곳이 있으면 말씀해주세요. (제가 테스트했을땐 에러나는 부분은 없었습니다....)

## 📸 스크린샷

<img width="1381" alt="image" src="https://github.com/13teamProject/Planit/assets/50002974/6d7a0b43-920e-4837-b86e-daee7df108aa">
<img width="1386" alt="image" src="https://github.com/13teamProject/Planit/assets/50002974/05b62a8e-68f2-4ecb-81ba-f563cd8ad289">
